### PR TITLE
Enable GitHub Pages build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# app-academias
+# App Academias
+
+Este é um aplicativo simples para academias feito em React. Ele possui uma interface para administradores e outra para alunos.
+
+## Hospedagem no GitHub Pages
+
+1. Faça o fork deste repositório para sua conta.
+2. Nas configurações do repositório no GitHub, habilite o GitHub Pages apontando para a branch `main` (diretório `/`).
+3. Acesse a URL fornecida pelo GitHub Pages para ver o app em execução.
+
+Para testar localmente, basta abrir o arquivo `index.html` em um navegador moderno.

--- a/app.js
+++ b/app.js
@@ -1,5 +1,36 @@
-import React, { useState, useEffect, createContext, useContext } from 'react';
-import { LogIn, UserPlus, Dumbbell, LogOut, ArrowLeft, PlusCircle, Save, Trash2, User, Users, ClipboardList, DollarSign, BookCopy, CheckSquare, Square, Settings, ChevronsRight, Coffee, HeartPulse, Repeat, Ruler, AlertTriangle, Calendar, ChevronLeft, ChevronRight, Timer, Edit, Home, X, Share } from 'lucide-react';
+const { useState, useEffect, createContext, useContext } = React;
+const {
+    LogIn,
+    UserPlus,
+    Dumbbell,
+    LogOut,
+    ArrowLeft,
+    PlusCircle,
+    Save,
+    Trash2,
+    User,
+    Users,
+    ClipboardList,
+    DollarSign,
+    BookCopy,
+    CheckSquare,
+    Square,
+    Settings,
+    ChevronsRight,
+    Coffee,
+    HeartPulse,
+    Repeat,
+    Ruler,
+    AlertTriangle,
+    Calendar,
+    ChevronLeft,
+    ChevronRight,
+    Timer,
+    Edit,
+    Home,
+    X,
+    Share
+} = LucideReact;
 
 // --- GERENCIADOR DE DADOS (LocalStorage) ---
 const db = {
@@ -1271,13 +1302,13 @@ const TrainingHistoryPage = () => {
 };
 
 // --- COMPONENTE PRINCIPAL DO APP ---
-export default function App() {
+const App = () => {
     useEffect(() => {
         initializeLocalDb();
     }, []);
 
     return (<AuthProvider><MainApp /></AuthProvider>);
-}
+};
 
 const MainApp = () => {
     const { user, logout, loading } = useAuth();
@@ -1426,3 +1457,6 @@ const InstallPWA = () => {
 
     return null;
 };
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Academia App</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/lucide-react@latest/dist/umd/lucide-react.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="bg-gray-100">
+  <div id="root"></div>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove ES module imports and use global React variables
- add index.html with CDN references to React, ReactDOM and Babel
- improve README with GitHub Pages instructions
- render `App` into `#root`

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688ada0a1af88332b81df9d484afdc1c