### PR TITLE
Fix lucide-react integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
   <title>Academia App</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <!-- lucide-react UMD expects `window.react` -->
+  <script>window.react = React;</script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/lucide-react@latest/dist/umd/lucide-react.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>


### PR DESCRIPTION
## Summary
- ensure lucide-react script receives the React global

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/app-academias/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688add51ea988332beea40cde7e69641