### PR TITLE
Add Firebase auth and member storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,6 +32,9 @@ const {
     Share
 } = LucideReact;
 
+const firebaseAuth = firebase.auth();
+const firebaseDb = firebase.firestore();
+
 // --- GERENCIADOR DE DADOS (LocalStorage) ---
 const db = {
     getItem: (key) => {
@@ -73,14 +76,16 @@ const AuthProvider = ({ children }) => {
         if (loggedInUser) setUser(loggedInUser);
         setLoading(false);
     }, []);
-    const login = (email, password) => {
-        const foundUser = (db.getItem('gym_users') || []).find(u => u.email === email && u.password === password);
-        if (foundUser) {
-            db.setItem('gym_current_user', foundUser);
-            setUser(foundUser);
+    const login = async (email, password) => {
+        try {
+            const cred = await firebaseAuth.signInWithEmailAndPassword(email, password);
+            const userData = { id: cred.user.uid, email: cred.user.email, role: 'admin' };
+            db.setItem('gym_current_user', userData);
+            setUser(userData);
             return { success: true };
+        } catch (err) {
+            return { success: false, message: 'Email ou senha inválidos.' };
         }
-        return { success: false, message: 'Email ou senha inválidos.' };
     };
     const logout = () => {
         db.setItem('gym_current_user', null);
@@ -259,9 +264,9 @@ const LoginPage = () => {
     const [password, setPassword] = useState('');
     const [error, setError] = useState('');
     const { login } = useAuth();
-    const handleLogin = (e) => {
+    const handleLogin = async (e) => {
         e.preventDefault(); setError('');
-        const result = login(email, password);
+        const result = await login(email, password);
         if (!result.success) setError(result.message);
     };
     return (
@@ -381,18 +386,24 @@ const AddMemberForm = ({ setPage }) => {
     const [plans, setPlans] = useState([]);
     const [modalInfo, setModalInfo] = useState({ show: false, message: '' });
     useEffect(() => { setPlans(db.getItem('gym_plans') || []); }, []);
-    const handleAddMember = (e) => {
+    const handleAddMember = async (e) => {
         e.preventDefault();
         if (!planId) { setModalInfo({ show: true, message: 'Selecione um plano.' }); return; }
         const users = db.getItem('gym_users') || [];
         if (users.some(u => u.email === email)) { setModalInfo({ show: true, message: 'Email já em uso.' }); return; }
-        users.push({
+        const newMember = {
             id: `user_${Date.now()}`, name, email, password, role: 'member',
             planId, joinDate: new Date().toISOString(), paymentHistory: [],
             sheetId: null, currentWorkoutIndex: 0,
             personalSheetId: null, currentPersonalWorkoutIndex: 0, activeTrainingMode: 'assisted'
-        });
+        };
+        users.push(newMember);
         db.setItem('gym_users', users);
+        try {
+            await firebaseDb.collection('members').doc(newMember.id).set(newMember);
+        } catch (err) {
+            console.error('Erro ao salvar no Firebase', err);
+        }
         setModalInfo({ show: true, message: `Aluno ${name} cadastrado!` });
         setName(''); setEmail(''); setPassword(''); setPlanId('');
     };

--- a/index.html
+++ b/index.html
@@ -5,9 +5,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Academia App</title>
   <script src="https://cdn.tailwindcss.com"></script>
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js" onload="window.react = window.React"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/lucide-react@latest/dist/umd/lucide-react.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
+  <script defer src="https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore-compat.js"></script>
+  <script>
+    const firebaseConfig = {
+      apiKey: "YOUR_API_KEY",
+      authDomain: "YOUR_AUTH_DOMAIN",
+      projectId: "YOUR_PROJECT_ID",
+      storageBucket: "YOUR_STORAGE_BUCKET",
+      messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+      appId: "YOUR_APP_ID"
+    };
+    firebase.initializeApp(firebaseConfig);
+  </script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="bg-gray-100">


### PR DESCRIPTION
## Summary
- integrate Firebase libraries and initialization in `index.html`
- use Firebase Authentication for admin login
- save new members to Firestore when registering

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/app-academias/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688add51ea988332beea40cde7e69641